### PR TITLE
Fixed spelling of `quiet`.

### DIFF
--- a/cmd/parcel/main.go
+++ b/cmd/parcel/main.go
@@ -30,7 +30,7 @@ func main() {
 		Action:               run,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
-				Name:  "quite, q",
+				Name:  "quiet, q",
 				Usage: "Disable logging",
 			},
 			cli.BoolFlag{


### PR DESCRIPTION
This pull-request updates the spelling of `quiet` to be correct.

### Description
Please explain the changes you made here.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file
